### PR TITLE
Plugin didn't work on iOS since version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ let TTS = new TNSTextToSpeech();
 
 let speakOptions: SpeakOptions = {
     text: 'Whatever you like', /// *** required ***
-    speakRate: 0.5 // optional - default is 1.0
-    pitch: 1.0 // optional - default is 1.0
-    volume: 1.0 // optional - default is 1.0
-    locale: "en-GB"  // optional - default is system locale,
+    speakRate: 0.5, // optional - default is 1.0
+    pitch: 1.0, // optional - default is 1.0
+    volume: 1.0, // optional - default is 1.0
+    locale: "en-GB",  // optional - default is system locale,
     finishedCallback: Function // optional
 }
 

--- a/texttospeech.ios.ts
+++ b/texttospeech.ios.ts
@@ -47,7 +47,7 @@ export class TNSTextToSpeech {
   private _speechSynthesizer: any; /// AVSpeechSynthesizer
 
   public speak(options: SpeakOptions): Promise<any> {
-    return new Promise(function(resolve, reject) {
+    return new Promise((resolve, reject) => {
       if (!this._speechSynthesizer) {
         this._speechSynthesizer = AVSpeechSynthesizer.alloc().init();
         this._speechSynthesizer.delegate = new MySpeechDelegate();


### PR DESCRIPTION
Hi,

For 2.0.0 the plugin was Promisified and a little mistake was made. When running this plugin on iOS the console is screaming stuff like `this_speechSynthesizer is undefined`.

I think [here](https://github.com/bradmartin/nativescript-texttospeech/pull/9/files#diff-96875b5b2566a9bd7d2afd2ec20ea5ceR50) it was a minor mistake of using `function` instead of `=>` to pass along the context of `this` into the function that was promisified.

Works like a charm when this little patch is applied.

Btw, I noticed this issue while trying to figure out the cause of #8, which I needed to tackle to get this little speech-to-text-to-speech UI working: Hold a button to record speech, show the result on screen and use this plugin to have the app shout it back at you.

![img_9592](https://user-images.githubusercontent.com/1426370/29745501-709895fe-8abc-11e7-93b5-efbfec78b36c.PNG)
