### PR TITLE
Added a stop() method, and updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ TTS.speak(speakOptions).then(
 
 - `speak(options: SpeakOptions): Promise<any>` - start speaking with the given options
 - `pause(): void` - pause the speech
+- `stop(): void` - stop the speech
 - `resume(): void` - resume the speech
 - `destroy(): void` - release resources for the speech synthesizer/engine
 
@@ -103,6 +104,10 @@ let speakOptions: SpeakOptions = {
 ### Android Only Methods
 
 - `getAvailableLanguages(): Promise<Array<Language>>;` - returns an array of available languages (use to prevent using non-existing language/local codes)
+
+### Android and iOS specific features
+
+The `pause()` is only supported on iOS. Android stops the speech and will resume from the start. Also both `pause()` and `stop()` takes one argument on iOS, indicating whether we should stop right now (`true`) or after the word being said (`false`).
 
 ## Credits
 

--- a/src/texttospeech.android.ts
+++ b/src/texttospeech.android.ts
@@ -94,8 +94,15 @@ export class TNSTextToSpeech {
   /**
    * Interrupts the current utterance and discards other utterances in the queue.
    * https://developer.android.com/reference/android/speech/tts/TextToSpeech.html#stop()
+   * Same as stop()
    */
   public pause() {
+    if (this._tts && this._initialized) {
+      this._tts.stop();
+    }
+  }
+
+  public stop() {
     if (this._tts && this._initialized) {
       this._tts.stop();
     }

--- a/src/texttospeech.ios.ts
+++ b/src/texttospeech.ios.ts
@@ -123,6 +123,12 @@ export class TNSTextToSpeech {
     );
   }
 
+  public stop(now) {
+    this._speechSynthesizer.stopSpeakingAtBoundary(
+      now ? AVSpeechBoundary.Immediate : AVSpeechBoundary.Word
+    );
+  }
+
   public resume() {
     this._speechSynthesizer.continueSpeaking();
   }


### PR DESCRIPTION
Because `pause()` is not behaving the same way on both iOS and Android, adding a `stop()` method is a better option IMHO.